### PR TITLE
fix(security) bump up Setuptools version

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -9,3 +9,4 @@ Flask-WTF==1.2.0
 email_validator==1.1.3
 python-dotenv==0.19.1
 Werkzeug==3.0.6
+Setuptools==70.0.0


### PR DESCRIPTION
Bumped up Setuptools version to 70.0.0 in order to fix the  CVE-2022-40897 and CVE-2024-6345 vulnerabilities.