### PR TITLE
fix - (security) nosec for false positive

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -55,6 +55,7 @@ class User(UserMixin, db.Model):
         """
         Return Gravatar URL based on email
         """
+        # nosec
         digest = md5(self.email.lower().encode('utf-8')).hexdigest()
         url = f'https://www.gravatar.com/avatar/{digest}?d=retro&s={size}'
         current_app.logger.debug(f"Get gravatar {url}")

--- a/app/models.py
+++ b/app/models.py
@@ -55,8 +55,7 @@ class User(UserMixin, db.Model):
         """
         Return Gravatar URL based on email
         """
-        # nosec
-        digest = md5(self.email.lower().encode('utf-8')).hexdigest()
+        digest = md5(self.email.lower().encode('utf-8')).hexdigest() #nosec
         url = f'https://www.gravatar.com/avatar/{digest}?d=retro&s={size}'
         current_app.logger.debug(f"Get gravatar {url}")
         return url


### PR DESCRIPTION
Adds nosec to the md5 profile image generation that caused a false positive vulnerability triggered by Bandit.  The reason for the false positive is that the md5 hash is merely used to generate a public profile picture and no secure information. 