### PR TITLE
Makefile adjustment and small docker security fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,8 @@ bandit:
 
 .PHONY: dockle
 dockle:
-	dockle --exit-code 1 weirdnessunfolds/devops:v11.1.0 2>&1 | grep -E 'FATAL|INFO' | sort
+	@docker build -t microblog . -f docker/Dockerfile_prod
+	@dockle --exit-code 1 microblog 2>&1 | grep -E 'FATAL|INFO' | sort
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ bandit:
 
 .PHONY: dockle
 dockle:
-	@docker build -t microblog . -f docker/Dockerfile_prod
+	@DOCKER_CONTENT_TRUST=1 docker build -t microblog . -f docker/Dockerfile_prod
 	@dockle --exit-code 1 microblog 2>&1 | grep -E 'FATAL|INFO' | sort
 
 

--- a/docker/Dockerfile_prod
+++ b/docker/Dockerfile_prod
@@ -21,4 +21,5 @@ ENV FLASK_APP=microblog.py
 USER microblog
 
 EXPOSE 5000
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD curl --fail http://localhost:5000/ || exit 1
 ENTRYPOINT ["./boot.sh"]


### PR DESCRIPTION

Adjusted the make dockle command to scan a local build of the docker production image, not the deployed one.

Also added a health check feature in the docker image, as well as setting the content trust to one in order to fix the CIS-DI-0005 and CIS-DI-0006 vulnerabilities.